### PR TITLE
#3019: replace static api url, use var netbox_api_path

### DIFF
--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -250,7 +250,7 @@ $(document).ready(function() {
 
         ajax: {
             delay: 250,
-            url: "/api/extras/tags/",
+            url: netbox_api_path + 'extras/tags/',
 
             data: function(params) {
                 // Paging. Note that `params.page` indexes at 1


### PR DESCRIPTION
### Fixes:
https://github.com/digitalocean/netbox/issues/3019
replace static api url, make use of variable `netbox_api_path` 
